### PR TITLE
Restart numbered lists

### DIFF
--- a/demo/29-numbered-lists.ts
+++ b/demo/29-numbered-lists.ts
@@ -1,54 +1,68 @@
 // Numbered lists
 // Import from 'docx' rather than '../build' if you install from npm
 import * as fs from "fs";
-import { AlignmentType, Document, Packer, Paragraph } from "../build";
+import { AlignmentType, File, Packer, Paragraph } from "../build";
 
-const doc = new Document({
-    numbering: {
-        config: [
-            {
-                levels: [
-                    {
-                        level: 0,
-                        format: "upperRoman",
-                        text: "%1",
-                        alignment: AlignmentType.START,
-                        style: {
-                            paragraph: {
-                                indent: { left: 720, hanging: 260 },
-                            },
-                        },
-                    },
-                ],
-                reference: "my-crazy-reference",
-            },
-            {
-                levels: [
-                    {
-                        level: 0,
-                        format: "decimal",
-                        text: "%1",
-                        alignment: AlignmentType.START,
-                        style: {
-                            paragraph: {
-                                indent: { left: 720, hanging: 260 },
-                            },
-                        },
-                    },
-                ],
-                reference: "my-number-numbering-reference",
-            },
-        ],
+const doc = new File({});
+
+const numbering1 = [
+  {
+    level: 0,
+    format: "upperRoman",
+    text: "%1",
+    alignment: AlignmentType.START,
+    style: {
+      paragraph: {
+        indent: { left: 720, hanging: 260 },
+      },
     },
-});
+  },
+];
+
+const numbering2 = [
+  {
+    level: 0,
+    format: "decimal",
+    text: "%1",
+    alignment: AlignmentType.START,
+    style: {
+      paragraph: {
+        indent: { left: 720, hanging: 260 },
+      },
+    },
+  },
+];
+
+const numbering = doc.Numbering;
+
+const abstractNumbering1 = numbering.createAbstractNumbering(numbering1);
+const abstractNumbering2 = numbering.createAbstractNumbering(numbering1);
+const abstractNumbering3 = numbering.createAbstractNumbering(numbering2);
+
+const concreteNumbering1 = numbering.createConcreteNumbering(abstractNumbering1, "reference", 1);
+const concreteNumbering2 = numbering.createConcreteNumbering(abstractNumbering2, "reference", 2);
+const concreteNumbering3 = numbering.createConcreteNumbering(abstractNumbering3, "reference", 3);
 
 doc.addSection({
     children: [
         new Paragraph({
-            text: "line with contextual spacing",
+            text: "bananas",
             numbering: {
-                reference: "my-crazy-reference",
+                reference:concreteNumbering1.reference!,
                 level: 0,
+                numId: 1,
+            },
+            contextualSpacing: true,
+            spacing: {
+                before: 200,
+            },
+        }),
+        new Paragraph({
+            text: "apples",
+            numbering: {
+                reference: concreteNumbering1.reference!,
+                level: 0,
+                numId: 1,
             },
             contextualSpacing: true,
             spacing: {
@@ -58,8 +72,21 @@ doc.addSection({
         new Paragraph({
             text: "line with contextual spacing",
             numbering: {
-                reference: "my-crazy-reference",
+                reference: concreteNumbering2.reference!,
                 level: 0,
+                numId: 2,
+            },
+            contextualSpacing: true,
+            spacing: {
+                before: 200,
+            },
+        }),
+        new Paragraph({
+            text: "line with contextual spacing",
+            numbering: {
+                reference: concreteNumbering2.reference!,
+                level: 0,
+                numId: 2,
             },
             contextualSpacing: true,
             spacing: {
@@ -69,8 +96,9 @@ doc.addSection({
         new Paragraph({
             text: "line without contextual spacing",
             numbering: {
-                reference: "my-crazy-reference",
+                reference: concreteNumbering2.reference!,
                 level: 0,
+                numId: 2,
             },
             contextualSpacing: false,
             spacing: {
@@ -80,8 +108,9 @@ doc.addSection({
         new Paragraph({
             text: "line without contextual spacing",
             numbering: {
-                reference: "my-crazy-reference",
+                reference: concreteNumbering2.reference!,
                 level: 0,
+                numId: 2,
             },
             contextualSpacing: false,
             spacing: {
@@ -91,22 +120,25 @@ doc.addSection({
         new Paragraph({
             text: "Step 1 - Add sugar",
             numbering: {
-                reference: "my-number-numbering-reference",
+                reference: concreteNumbering3.reference!,
                 level: 0,
+                numId: 3,
             },
         }),
         new Paragraph({
             text: "Step 2 - Add wheat",
             numbering: {
-                reference: "my-number-numbering-reference",
+                reference: concreteNumbering3.reference!,
                 level: 0,
+                numId: 3,
             },
         }),
         new Paragraph({
             text: "Step 3 - Put in oven",
             numbering: {
-                reference: "my-number-numbering-reference",
+                reference: concreteNumbering3.reference!,
                 level: 0,
+                numId: 3,
             },
         }),
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docx",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/file/numbering/numbering.ts
+++ b/src/file/numbering/numbering.ts
@@ -47,113 +47,115 @@ export class Numbering extends XmlComponent {
 
         this.nextId = 0;
 
-        const abstractNumbering = this.createAbstractNumbering([
-            {
-                level: 0,
-                format: "bullet",
-                text: "\u25CF",
-                alignment: AlignmentType.LEFT,
-                style: {
-                    paragraph: {
-                        indent: { left: 720, hanging: 360 },
+        if (!options.config) {
+            const abstractNumbering = this.createAbstractNumbering([
+                {
+                    level: 0,
+                    format: "bullet",
+                    text: "\u25CF",
+                    alignment: AlignmentType.LEFT,
+                    style: {
+                        paragraph: {
+                            indent: { left: 720, hanging: 360 },
+                        },
                     },
                 },
-            },
-            {
-                level: 1,
-                format: "bullet",
-                text: "\u25CB",
-                alignment: AlignmentType.LEFT,
-                style: {
-                    paragraph: {
-                        indent: { left: 1440, hanging: 360 },
+                {
+                    level: 1,
+                    format: "bullet",
+                    text: "\u25CB",
+                    alignment: AlignmentType.LEFT,
+                    style: {
+                        paragraph: {
+                            indent: { left: 1440, hanging: 360 },
+                        },
                     },
                 },
-            },
-            {
-                level: 2,
-                format: "bullet",
-                text: "\u25A0",
-                alignment: AlignmentType.LEFT,
-                style: {
-                    paragraph: {
-                        indent: { left: 2160, hanging: 360 },
+                {
+                    level: 2,
+                    format: "bullet",
+                    text: "\u25A0",
+                    alignment: AlignmentType.LEFT,
+                    style: {
+                        paragraph: {
+                            indent: { left: 2160, hanging: 360 },
+                        },
                     },
                 },
-            },
-            {
-                level: 3,
-                format: "bullet",
-                text: "\u25CF",
-                alignment: AlignmentType.LEFT,
-                style: {
-                    paragraph: {
-                        indent: { left: 2880, hanging: 360 },
+                {
+                    level: 3,
+                    format: "bullet",
+                    text: "\u25CF",
+                    alignment: AlignmentType.LEFT,
+                    style: {
+                        paragraph: {
+                            indent: { left: 2880, hanging: 360 },
+                        },
                     },
                 },
-            },
-            {
-                level: 4,
-                format: "bullet",
-                text: "\u25CB",
-                alignment: AlignmentType.LEFT,
-                style: {
-                    paragraph: {
-                        indent: { left: 3600, hanging: 360 },
+                {
+                    level: 4,
+                    format: "bullet",
+                    text: "\u25CB",
+                    alignment: AlignmentType.LEFT,
+                    style: {
+                        paragraph: {
+                            indent: { left: 3600, hanging: 360 },
+                        },
                     },
                 },
-            },
-            {
-                level: 5,
-                format: "bullet",
-                text: "\u25A0",
-                alignment: AlignmentType.LEFT,
-                style: {
-                    paragraph: {
-                        indent: { left: 4320, hanging: 360 },
+                {
+                    level: 5,
+                    format: "bullet",
+                    text: "\u25A0",
+                    alignment: AlignmentType.LEFT,
+                    style: {
+                        paragraph: {
+                            indent: { left: 4320, hanging: 360 },
+                        },
                     },
                 },
-            },
-            {
-                level: 6,
-                format: "bullet",
-                text: "\u25CF",
-                alignment: AlignmentType.LEFT,
-                style: {
-                    paragraph: {
-                        indent: { left: 5040, hanging: 360 },
+                {
+                    level: 6,
+                    format: "bullet",
+                    text: "\u25CF",
+                    alignment: AlignmentType.LEFT,
+                    style: {
+                        paragraph: {
+                            indent: { left: 5040, hanging: 360 },
+                        },
                     },
                 },
-            },
-            {
-                level: 7,
-                format: "bullet",
-                text: "\u25CF",
-                alignment: AlignmentType.LEFT,
-                style: {
-                    paragraph: {
-                        indent: { left: 5760, hanging: 360 },
+                {
+                    level: 7,
+                    format: "bullet",
+                    text: "\u25CF",
+                    alignment: AlignmentType.LEFT,
+                    style: {
+                        paragraph: {
+                            indent: { left: 5760, hanging: 360 },
+                        },
                     },
                 },
-            },
-            {
-                level: 8,
-                format: "bullet",
-                text: "\u25CF",
-                alignment: AlignmentType.LEFT,
-                style: {
-                    paragraph: {
-                        indent: { left: 6480, hanging: 360 },
+                {
+                    level: 8,
+                    format: "bullet",
+                    text: "\u25CF",
+                    alignment: AlignmentType.LEFT,
+                    style: {
+                        paragraph: {
+                            indent: { left: 6480, hanging: 360 },
+                        },
                     },
                 },
-            },
-        ]);
+            ]);
 
-        this.createConcreteNumbering(abstractNumbering);
-
-        for (const con of options.config) {
-            const currentAbstractNumbering = this.createAbstractNumbering(con.levels);
-            this.createConcreteNumbering(currentAbstractNumbering, con.reference);
+            this.createConcreteNumbering(abstractNumbering);
+        } else {
+            for (const con of options.config) {
+                const currentAbstractNumbering = this.createAbstractNumbering(con.levels);
+                this.createConcreteNumbering(currentAbstractNumbering, con.reference);
+            }
         }
     }
 
@@ -163,13 +165,13 @@ export class Numbering extends XmlComponent {
         return super.prepForXml();
     }
 
-    private createConcreteNumbering(abstractNumbering: AbstractNumbering, reference?: string): ConcreteNumbering {
-        const num = new ConcreteNumbering(this.nextId++, abstractNumbering.id, reference);
+    public createConcreteNumbering(abstractNumbering: AbstractNumbering, reference?: string, numId?: number): ConcreteNumbering {
+        const num = new ConcreteNumbering(numId || this.nextId++, abstractNumbering.id, reference);
         this.concreteNumbering.push(num);
         return num;
     }
 
-    private createAbstractNumbering(options: ILevelsOptions[]): AbstractNumbering {
+    public createAbstractNumbering(options: ILevelsOptions[]): AbstractNumbering {
         const num = new AbstractNumbering(this.nextId++, options);
         this.abstractNumbering.push(num);
         return num;

--- a/src/file/paragraph/paragraph.ts
+++ b/src/file/paragraph/paragraph.ts
@@ -43,6 +43,7 @@ export interface IParagraphOptions {
     readonly numbering?: {
         readonly reference: string;
         readonly level: number;
+        readonly numId?: number;
         readonly custom?: boolean;
     };
     readonly children?: Array<
@@ -143,7 +144,11 @@ export class Paragraph extends XmlComponent {
             if (!options.numbering.custom) {
                 this.properties.push(new Style("ListParagraph"));
             }
-            this.properties.push(new NumberProperties(options.numbering.reference, options.numbering.level));
+            if (options.numbering.numId) {
+                this.properties.push(new NumberProperties(options.numbering.numId, options.numbering.level));
+            } else {
+                this.properties.push(new NumberProperties(options.numbering.reference, options.numbering.level));
+            }
         }
 
         if (options.children) {


### PR DESCRIPTION
This PR makes it possible to restart the numbering of numbered lists.
In order to do this, we need to:
1) create an abstract and a concrete numbering for each list (even when they use the same levels config) 
2) assign a similar `numId` to each entry of the same list

The numbered lists demo `demo/29-numbered-lists.ts` was updated in order to showcase the feature and this is a screenshot of the resulting doc:
<img width="522" alt="Screenshot 2020-06-25 at 12 11 49" src="https://user-images.githubusercontent.com/1684627/85702091-58fa1200-b6de-11ea-9641-615662a16de8.png">

