### PR TITLE
feat: add level restart property

### DIFF
--- a/src/file/numbering/level.ts
+++ b/src/file/numbering/level.ts
@@ -71,6 +71,17 @@ class LevelJc extends XmlComponent {
     }
 }
 
+class LvlRestart extends XmlComponent {
+    constructor(value: number) {
+        super("w:lvlRestart");
+        this.root.push(
+            new Attributes({
+                val: value,
+            }),
+        );
+    }
+}
+
 export enum LevelSuffix {
     NOTHING = "nothing",
     SPACE = "space",
@@ -88,6 +99,7 @@ export interface ILevelsOptions {
         readonly run?: IRunStyleOptions;
         readonly paragraph?: IParagraphStyleOptions2;
     };
+    readonly levelRestart?: number;
 }
 
 class Suffix extends XmlComponent {
@@ -105,7 +117,7 @@ export class LevelBase extends XmlComponent {
     private readonly paragraphProperties: ParagraphProperties;
     private readonly runProperties: RunProperties;
 
-    constructor({ level, format, text, alignment = AlignmentType.START, start = 1, style, suffix }: ILevelsOptions) {
+    constructor({ level, format, text, alignment = AlignmentType.START, start = 1, style, suffix, levelRestart }: ILevelsOptions) {
         super("w:lvl");
         this.root.push(
             new LevelAttributes({
@@ -119,6 +131,10 @@ export class LevelBase extends XmlComponent {
 
         if (format) {
             this.root.push(new NumberFormat(format));
+        }
+
+        if (levelRestart !== undefined) {
+            this.root.push(new LvlRestart(levelRestart));
         }
 
         if (text) {


### PR DESCRIPTION
Add the property "lvlRestart" to numbering levels. By setting this property to 0, when can prevent the numbering of this level to restart whenever a new higher-level numbering section starts.